### PR TITLE
feat(ui): polish target badges and mirror badges in OSD

### DIFF
--- a/src/features/osd/osd.js
+++ b/src/features/osd/osd.js
@@ -15,6 +15,72 @@ export function createOsdFeature({
 
   const activeOsdCards = new Map();
 
+  function parseLabelParts(rawLabel) {
+    const label = String(rawLabel || "").trim();
+    if (!label) return { base: "", tags: [] };
+
+    const tags = [];
+    const tagPattern = /\(([^()]+)\)/g;
+    let match = null;
+    while ((match = tagPattern.exec(label)) !== null) {
+      const tag = String(match[1] || "").trim();
+      if (tag) tags.push(tag);
+    }
+
+    const base = label.replace(/\s*\([^()]+\)/g, " ").replace(/\s+/g, " ").trim();
+    return { base: base || label, tags };
+  }
+
+  function tagVariant(tag) {
+    const text = String(tag || "").toLowerCase();
+    if (!text) return "neutral";
+    if (text.includes("mix")) return "mix";
+    if (
+      text.includes("toggle")
+      || text.includes("mute")
+      || text.includes("media")
+      || text.includes("stop")
+      || text.includes("play")
+      || text.includes("next")
+      || text.includes("prev")
+      || text.includes("record")
+      || text.includes("stream")
+      || text.includes("visibility")
+      || text.includes("trigger")
+      || text.includes("action")
+    ) {
+      return "action";
+    }
+    return "neutral";
+  }
+
+  function renderLabelWithTags(host, rawLabel) {
+    host.innerHTML = "";
+    const { base, tags } = parseLabelParts(rawLabel);
+
+    const content = document.createElement("span");
+    content.className = "osd-label-content";
+
+    const main = document.createElement("span");
+    main.className = "osd-label-main";
+    main.textContent = base || rawLabel || "Target";
+    content.appendChild(main);
+
+    if (tags.length > 0) {
+      const tagsWrap = document.createElement("span");
+      tagsWrap.className = "osd-label-tags";
+      tags.forEach((tag) => {
+        const badge = document.createElement("span");
+        badge.className = `osd-tag osd-tag--${tagVariant(tag)}`;
+        badge.textContent = tag;
+        tagsWrap.appendChild(badge);
+      });
+      content.appendChild(tagsWrap);
+    }
+
+    host.appendChild(content);
+  }
+
   function getOsdKey(target) {
     const key = keyForTarget(target);
     if (key) return key;
@@ -98,7 +164,7 @@ export function createOsdFeature({
       refs.card.classList.add("visible");
     }
 
-    refs.labelSpan.textContent = display.label;
+    renderLabelWithTags(refs.labelSpan, display.label);
     refs.iconDiv.innerHTML = "";
     const icon = iconFor({ label: display.label, icon_data: display.icon_data });
     refs.iconDiv.appendChild(icon);
@@ -146,7 +212,7 @@ export function createOsdFeature({
       refs.card.classList.add("visible");
     }
 
-    refs.labelSpan.textContent = display.label;
+    renderLabelWithTags(refs.labelSpan, display.label);
     refs.iconDiv.innerHTML = "";
     const icon = iconFor(display);
     refs.iconDiv.appendChild(icon);

--- a/src/features/targets/targets.js
+++ b/src/features/targets/targets.js
@@ -33,6 +33,119 @@ export function createTargetsFeature({
     return mediaPlayPauseIconData;
   }
 
+  function parseLabelParts(rawLabel) {
+    const label = String(rawLabel || "").trim();
+    if (!label) {
+      return { base: "", tags: [] };
+    }
+
+    const tags = [];
+    const tagPattern = /\(([^()]+)\)/g;
+    let match = null;
+    while ((match = tagPattern.exec(label)) !== null) {
+      const tag = String(match[1] || "").trim();
+      if (tag) tags.push(tag);
+    }
+
+    const base = label.replace(/\s*\([^()]+\)/g, " ").replace(/\s+/g, " ").trim();
+    return { base: base || label, tags };
+  }
+
+  function tagVariant(tag) {
+    const text = String(tag || "").toLowerCase();
+    if (!text) return "neutral";
+    if (text.includes("mix")) return "mix";
+    if (text.includes("unavailable") || text.includes("disconnected") || text.includes("connecting")) {
+      return "state";
+    }
+    if (
+      text.includes("toggle")
+      || text.includes("mute")
+      || text.includes("media")
+      || text.includes("stop")
+      || text.includes("play")
+      || text.includes("next")
+      || text.includes("prev")
+      || text.includes("record")
+      || text.includes("stream")
+      || text.includes("visibility")
+      || text.includes("trigger")
+      || text.includes("action")
+    ) {
+      return "action";
+    }
+    return "neutral";
+  }
+
+  function appendLabelWithTags(labelEl, rawLabel, extraTags = [], truncateMain = true) {
+    labelEl.textContent = "";
+    const { base, tags } = parseLabelParts(rawLabel);
+    const allTags = [...tags, ...extraTags.filter(Boolean).map((t) => String(t).trim()).filter(Boolean)];
+    const uniqueTags = [];
+    const seenTags = new Set();
+    for (const tag of allTags) {
+      const key = tag.toLowerCase();
+      if (seenTags.has(key)) continue;
+      seenTags.add(key);
+      uniqueTags.push(tag);
+    }
+
+    let visibleTags = uniqueTags.map((tag) => ({ text: tag, kind: tagVariant(tag), hiddenTags: [] }));
+    if (truncateMain && uniqueTags.length > 1) {
+      const baseLen = (base || rawLabel || "").length;
+      const tagTextLen = uniqueTags.reduce((sum, t) => sum + String(t).length, 0);
+      const shouldCollapse = uniqueTags.length > 2 || (baseLen + tagTextLen > 24);
+
+      if (!shouldCollapse) {
+        const keepAll = uniqueTags.map((tag) => ({ text: tag, kind: tagVariant(tag), hiddenTags: [] }));
+        visibleTags = keepAll;
+      } else {
+      const tagPriority = (tag) => {
+        const variant = tagVariant(tag);
+        if (variant === "action") return 0;
+        if (variant === "mix") return 1;
+        if (variant === "state") return 2;
+        return 3;
+      };
+      const sorted = [...uniqueTags].sort((a, b) => tagPriority(a) - tagPriority(b));
+      const first = sorted[0];
+      const hidden = sorted.slice(1);
+      const restCount = hidden.length;
+      visibleTags = [{ text: first, kind: tagVariant(first), hiddenTags: [] }];
+      if (restCount > 0) {
+        visibleTags.push({ text: `+${restCount}`, kind: "count", hiddenTags: hidden });
+      }
+      }
+    }
+
+    const content = document.createElement("span");
+    content.className = "target-label-content";
+
+    const main = document.createElement("span");
+    main.className = `target-label-main${truncateMain ? " is-truncated" : ""}`;
+    main.textContent = base || rawLabel || "Target";
+    content.appendChild(main);
+
+    if (visibleTags.length > 0) {
+      const tagsWrap = document.createElement("span");
+      tagsWrap.className = "target-label-tags";
+      visibleTags.forEach((tag) => {
+        const badge = document.createElement("span");
+        badge.className = `target-tag target-tag--${tag.kind}`;
+        badge.textContent = tag.text;
+        if (tag.kind === "count" && tag.hiddenTags.length > 0) {
+          const hiddenList = tag.hiddenTags.join(", ");
+          badge.title = hiddenList;
+          badge.setAttribute("aria-label", `Additional tags: ${hiddenList}`);
+        }
+        tagsWrap.appendChild(badge);
+      });
+      content.appendChild(tagsWrap);
+    }
+
+    labelEl.appendChild(content);
+  }
+
   function closeTargetMenus(except = null) {
     document.querySelectorAll(".target-dropdown.open").forEach((dropdown) => {
       if (dropdown === except) {
@@ -116,7 +229,7 @@ export function createTargetsFeature({
       item.appendChild(createTargetIcon(option));
       const label = document.createElement("span");
       label.className = "target-label";
-      label.textContent = option.label;
+      appendLabelWithTags(label, option.label, [], false);
       item.appendChild(label);
       item.classList.toggle(
         "selected",
@@ -398,12 +511,8 @@ export function createTargetsFeature({
       const icon = createTargetIcon(displayOption);
       const label = document.createElement("span");
       label.className = "target-label";
-
-      let text = option.label;
-      if (action && isBindingButton) {
-        text += ` (${actionLabel(action)})`;
-      }
-      label.textContent = text;
+      const actionTag = (action && isBindingButton) ? actionLabel(action) : null;
+      appendLabelWithTags(label, option.label, actionTag ? [actionTag] : [], true);
 
       display.appendChild(icon);
       display.appendChild(label);

--- a/src/styles.css
+++ b/src/styles.css
@@ -347,9 +347,86 @@ button:hover {
 }
 
 .target-label {
+  min-width: 0;
+  flex: 1;
+}
+
+.target-label-content {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.target-label-main {
+  min-width: 0;
+}
+
+.target-label-main.is-truncated {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.target-label-tags {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+
+.target-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px 5px;
+  border-radius: 5px;
+  border: 1px solid transparent;
+  font-size: 9px;
+  line-height: 1.3;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  max-width: 84px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.target-tag--mix {
+  background: #e8f3ff;
+  border-color: #c8dcfb;
+  color: #1f4f85;
+}
+
+.target-tag--action {
+  background: #fff1e3;
+  border-color: #f5d8b4;
+  color: #8a4b12;
+}
+
+.target-tag--state {
+  background: #fdebec;
+  border-color: #f4c2c7;
+  color: #9d2d33;
+}
+
+.target-tag--neutral {
+  background: #e9edf5;
+  border-color: #d2dae8;
+  color: #3d4863;
+}
+
+.target-tag--count {
+  background: #edf0f6;
+  border-color: #d6ddea;
+  color: #495472;
+  max-width: 34px;
+  cursor: help;
 }
 
 .target-placeholder {
@@ -687,13 +764,36 @@ button:hover {
 
 .target-panel .target-label {
   white-space: normal;
+}
+
+.target-panel .target-label-content {
+  align-items: flex-start;
+  flex-wrap: wrap;
   overflow: visible;
-  text-overflow: clip;
+}
+
+.target-panel .target-label-main {
+  white-space: normal;
+}
+
+.target-panel .target-label-tags {
+  flex-wrap: wrap;
+  overflow: visible;
+}
+
+.target-panel .target-tag {
+  max-width: none;
+  font-size: 10px;
+}
+
+.target-display .target-label-content {
+  flex-wrap: nowrap;
+  row-gap: 0;
 }
 
 .target-option {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
   width: 100%;
   background: #f4f5fa;
@@ -1105,6 +1205,55 @@ body.osd-only .osd {
   min-width: 0;
   /* Allow text to wrap */
   word-break: break-word;
+}
+
+.osd-label-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.osd-label-main {
+  min-width: 0;
+}
+
+.osd-label-tags {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.osd-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px 6px;
+  border-radius: 5px;
+  border: 1px solid transparent;
+  font-size: 10px;
+  line-height: 1.3;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.osd-tag--mix {
+  background: rgba(129, 183, 255, 0.22);
+  border-color: rgba(129, 183, 255, 0.45);
+  color: #d7e9ff;
+}
+
+.osd-tag--action {
+  background: rgba(255, 190, 110, 0.2);
+  border-color: rgba(255, 190, 110, 0.45);
+  color: #ffe4bf;
+}
+
+.osd-tag--neutral {
+  background: rgba(197, 207, 228, 0.22);
+  border-color: rgba(197, 207, 228, 0.45);
+  color: #edf2ff;
 }
 
 .osd-value {


### PR DESCRIPTION
Improves target label readability by rendering parenthetical suffixes as compact badges, and extends the same badge treatment to OSD labels.

This keeps the target row easier to scan when labels include multiple qualifiers (for example mix/action tags), while preserving the existing data model and behavior.

Also updates overflow behavior in target displays so crowded labels collapse intelligently and expose hidden tag details via the count badge tooltip, and fixes picker badge clipping in long device names.

Files changed:
- src/features/targets/targets.js
- src/features/osd/osd.js
- src/styles.css