### PR TITLE
feat(ui): add persistent dark mode toggle

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -18,6 +18,12 @@
       <button id="connections-button" class="header-icon-button" type="button" aria-label="Open plugins">
         🔗
       </button>
+      <button id="theme-toggle-button" class="header-icon-button" type="button" aria-label="Switch to dark mode" title="Switch to dark mode" aria-pressed="false">
+        <svg class="theme-toggle-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path class="icon-stars" d="M8.6 6.1L9.3 7.7 10.9 8.4 9.3 9.1 8.6 10.7 7.9 9.1 6.3 8.4 7.9 7.7ZM5.2 10.9L5.7 12 6.8 12.5 5.7 13 5.2 14.1 4.7 13 3.6 12.5 4.7 12ZM8.1 14.5L8.7 15.8 10 16.4 8.7 17 8.1 18.3 7.5 17 6.2 16.4 7.5 15.8Z" />
+          <path class="icon-crescent" d="M15.9 2.2a.9.9 0 0 1 1.02 1.26A8.3 8.3 0 1 0 20.35 13.7a.9.9 0 0 1 1.33.97A10.2 10.2 0 1 1 15.9 2.2Z" />
+        </svg>
+      </button>
       <button id="settings-button" class="header-icon-button" type="button" aria-label="Open settings">
         ⚙
       </button>

--- a/src/main.js
+++ b/src/main.js
@@ -256,6 +256,7 @@ const learnPanel = document.getElementById("learn-panel");
 const learnPanelMessage = document.getElementById("learn-panel-message");
 const learnPanelClose = document.getElementById("learn-panel-close");
 const settingsButton = document.getElementById("settings-button");
+const themeToggleButton = document.getElementById("theme-toggle-button");
 const settingsPanel = document.getElementById("settings-panel");
 const settingsPanelClose = document.getElementById("settings-panel-close");
 const connectionsButton = document.getElementById("connections-button");
@@ -303,6 +304,44 @@ const mediaPrevTrackIconData = "data:image/svg+xml;utf8,<svg xmlns='http://www.w
 const mediaStopIconData = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18'><rect width='18' height='18' rx='4' fill='%232b2d42'/><rect x='5' y='5' width='8' height='8' rx='1.2' fill='white'/></svg>";
 const osdDebugAlways = false;
 const isOsdWindow = new URLSearchParams(window.location.search).has("osd");
+const themeStorageKey = "uiTheme";
+
+function updateThemeToggleMeta(isDark) {
+  if (!themeToggleButton) return;
+  const label = isDark ? "Switch to light mode" : "Switch to dark mode";
+  themeToggleButton.setAttribute("aria-label", label);
+  themeToggleButton.setAttribute("aria-pressed", String(isDark));
+  themeToggleButton.setAttribute("title", label);
+  themeToggleButton.title = label;
+}
+
+function applyTheme(nextTheme) {
+  const isDark = nextTheme === "dark";
+  document.body.classList.toggle("dark-mode", isDark);
+  updateThemeToggleMeta(isDark);
+}
+
+function loadStoredTheme() {
+  try {
+    const stored = localStorage.getItem(themeStorageKey);
+    if (stored === "light" || stored === "dark") {
+      return stored;
+    }
+  } catch {
+    // ignore storage failures
+  }
+  return "light";
+}
+
+function toggleTheme() {
+  const nextTheme = document.body.classList.contains("dark-mode") ? "light" : "dark";
+  applyTheme(nextTheme);
+  try {
+    localStorage.setItem(themeStorageKey, nextTheme);
+  } catch {
+    // ignore storage failures
+  }
+}
 
 const targetCore = createTargetCore({
   masterIconData,
@@ -335,6 +374,8 @@ const defaultOsdSettings = {
 
 if (isOsdWindow) {
   document.body.classList.add("osd-only");
+} else {
+  applyTheme(loadStoredTheme());
 }
 
 function showSetup(statusText) {
@@ -998,6 +1039,10 @@ if (connectionsButton) {
   connectionsButton.addEventListener("click", () => {
     openConnectionsPanel();
   });
+}
+
+if (themeToggleButton) {
+  themeToggleButton.addEventListener("click", toggleTheme);
 }
 
 if (alertClose) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,6 +32,10 @@ body.osd-only {
   background: transparent;
 }
 
+body.osd-only.dark-mode {
+  background: transparent;
+}
+
 body.osd-only header,
 body.osd-only main {
   display: none;
@@ -73,6 +77,396 @@ header {
 
 .header-icon-button:hover {
   background: rgba(255, 255, 255, 0.18);
+}
+
+.theme-toggle-icon {
+  width: 21px;
+  height: 21px;
+}
+
+.theme-toggle-icon .icon-stars,
+.theme-toggle-icon .icon-crescent {
+  fill: currentColor;
+}
+
+body.dark-mode .theme-toggle-icon .icon-crescent {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+body.dark-mode {
+  background: #101725;
+  color: #e8eefc;
+}
+
+body.dark-mode header {
+  background: #232a41;
+  border-bottom: 1px solid #222b40;
+}
+
+body.dark-mode .app-name {
+  color: #eaf0ff;
+  text-shadow: -1px 0 #0a0f1a, 0 1px #0a0f1a, 1px 0 #0a0f1a, 0 -1px #0a0f1a;
+}
+
+body.dark-mode .card,
+body.dark-mode .target-menu,
+body.dark-mode .target-panel-content,
+body.dark-mode .target-button,
+body.dark-mode .select-button,
+body.dark-mode .dropdown,
+body.dark-mode .dropdown-item button:first-child,
+body.dark-mode .binding-row input,
+body.dark-mode .binding-row select,
+body.dark-mode select,
+body.dark-mode input,
+body.dark-mode textarea {
+  background: #1c2437;
+  color: #e8eefc;
+  border-color: #3b4b6f;
+}
+
+body.dark-mode .target-button:hover,
+body.dark-mode .dropdown-item button:first-child:hover {
+  background: #2a3551;
+}
+
+body.dark-mode .target-panel-header,
+body.dark-mode .status,
+body.dark-mode .binding-headers,
+body.dark-mode .settings-title,
+body.dark-mode .target-placeholder,
+body.dark-mode .bindings-empty,
+body.dark-mode .learn-panel-body {
+  color: #c9d3ed;
+}
+
+body.dark-mode .target-panel-header,
+body.dark-mode .dropdown-item,
+body.dark-mode .target-option,
+body.dark-mode .bindings-empty {
+  border-color: #3b4b6f;
+}
+
+body.dark-mode .bindings-empty {
+  background: #172034;
+}
+
+body.dark-mode .target-option:hover,
+body.dark-mode .target-option.selected {
+  background: #2a3551;
+}
+
+body.dark-mode .target-option {
+  background: #26314a;
+  color: #e8eefc;
+  border-color: #3b4b6f;
+}
+
+body.dark-mode .target-divider {
+  color: #9fb0d8;
+}
+
+body.dark-mode .target-panel {
+  background: rgba(8, 12, 22, 0.72);
+}
+
+body.dark-mode .osd-position-picker {
+  border-color: #6177aa;
+  background: #121a2b;
+  box-shadow: inset 0 0 0 1px rgba(142, 163, 214, 0.35);
+}
+
+body.dark-mode .header-icon-button {
+  border-color: rgba(176, 196, 241, 0.28);
+  background: rgba(176, 196, 241, 0.12);
+  color: #ecf2ff;
+}
+
+body.dark-mode .header-icon-button:hover {
+  background: rgba(176, 196, 241, 0.24);
+}
+
+body.dark-mode .icon-button,
+body.dark-mode .target-panel-back,
+body.dark-mode .target-panel-close {
+  color: #e6eaf5;
+}
+
+body.dark-mode .target-panel-back:hover,
+body.dark-mode .target-panel-close:hover {
+  background: #2a344d;
+}
+
+body.dark-mode .binding-action,
+body.dark-mode .icon-button {
+  background: #243250;
+  color: #e8eefc;
+  border-color: #556892;
+}
+
+body.dark-mode .binding-action:hover,
+body.dark-mode .icon-button:hover {
+  background: #304164;
+}
+
+body.dark-mode .binding-action.delete,
+body.dark-mode .icon-button.danger {
+  color: #ff9aa5;
+  border-color: #92566a;
+  background: #3b2a3a;
+}
+
+body.dark-mode .binding-add-footer {
+  background: #19233a;
+  border-color: #334468;
+}
+
+body.dark-mode .binding-add-button {
+  color: #dbe5ff;
+  border-color: #4f628e;
+}
+
+body.dark-mode .binding-add-button:hover {
+  background: #25324f;
+}
+
+body.dark-mode .profile-select .select-button {
+  background: #151d2e;
+  border-color: #4a5f8a;
+  box-shadow: inset 0 1px 0 rgba(201, 213, 242, 0.08);
+}
+
+body.dark-mode .profile-select .select-button:hover {
+  background: #1f2a42;
+}
+
+body.dark-mode .profile-select .dropdown {
+  background: #121a2a;
+  border-color: #3f5279;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.42);
+}
+
+body.dark-mode .profile-select .dropdown-item {
+  background: #1d2940;
+  color: #e8eefc;
+}
+
+body.dark-mode .profile-select .dropdown-item button {
+  color: #e8eefc;
+}
+
+body.dark-mode .profile-select .dropdown-item button:hover,
+body.dark-mode .profile-select .dropdown-item .delete:hover {
+  background: #2a3551;
+}
+
+body.dark-mode .profile-select .dropdown-item.create {
+  background: #141d30;
+  border-color: #4a5f8a;
+}
+
+body.dark-mode #setup-screen h2 {
+  color: #f1f5ff;
+}
+
+body.dark-mode #setup-screen p,
+body.dark-mode #setup-screen .status {
+  color: #b9c6e6;
+}
+
+body.dark-mode .form-group label {
+  color: #c9d3ed;
+}
+
+body.dark-mode .secondary-button {
+  background: #1c2437;
+  color: #e8eefc;
+  border-color: #4a5f8a;
+}
+
+body.dark-mode .secondary-button:hover {
+  background: #2a3551;
+}
+
+body.dark-mode .primary-button {
+  background: #4f6698;
+  border-color: #4f6698;
+  color: #f7faff;
+}
+
+body.dark-mode .primary-button:hover {
+  background: #5d79b2;
+}
+
+body.dark-mode * {
+  scrollbar-color: #5c709e #1a2235;
+}
+
+body.dark-mode *::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+body.dark-mode *::-webkit-scrollbar-track {
+  background: #1a2235;
+  border-radius: 10px;
+}
+
+body.dark-mode *::-webkit-scrollbar-thumb {
+  background: #5c709e;
+  border: 2px solid #1a2235;
+  border-radius: 10px;
+}
+
+body.dark-mode *::-webkit-scrollbar-thumb:hover {
+  background: #6f84b4;
+}
+
+body.dark-mode *::-webkit-scrollbar-corner {
+  background: #1a2235;
+}
+
+body.dark-mode .list-item {
+  background: #26314a;
+  box-shadow: inset 0 0 0 1px #35486c;
+}
+
+body.dark-mode .binding-placeholder {
+  background: #22304a;
+  border-color: #4f6594;
+}
+
+body.dark-mode .binding-ghost {
+  background: #26314a;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+}
+
+body.dark-mode .binding-item:hover {
+  background: #2a3551;
+}
+
+body.dark-mode .binding-name {
+  background: transparent;
+  border-color: transparent;
+  color: #eef3ff;
+}
+
+body.dark-mode .binding-name:focus {
+  background: #25324a;
+  border-color: #5b719f;
+}
+
+body.dark-mode .connections-panel-content {
+  background: #1a2235;
+}
+
+body.dark-mode .connections-sidebar {
+  background: #151d2e;
+  border-right-color: #334468;
+}
+
+body.dark-mode .connections-content {
+  background: #1a2235;
+}
+
+body.dark-mode .connections-nav-item {
+  color: #b9c6e6;
+}
+
+body.dark-mode .connections-nav-item:hover {
+  background: #273554;
+  color: #eff4ff;
+}
+
+body.dark-mode .connections-nav-item.active {
+  background: #22304a;
+  color: #f4f7ff;
+  border-color: #4a5f8a;
+}
+
+body.dark-mode .connections-nav-item .nav-icon {
+  background: rgba(222, 233, 255, 0.14);
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px rgba(222, 233, 255, 0.16);
+}
+
+body.dark-mode .connection-item-header {
+  border-bottom-color: #334468;
+}
+
+body.dark-mode .connection-name,
+body.dark-mode .plugins-store-row-name,
+body.dark-mode .plugins-manager-row-name {
+  color: #eef3ff;
+}
+
+body.dark-mode .plugins-manager-row,
+body.dark-mode .plugins-store-row,
+body.dark-mode .connection-description,
+body.dark-mode .connection-icon,
+body.dark-mode .connection-status {
+  background: #222d45;
+  border-color: #4a5f8a;
+  color: #c9d3ed;
+}
+
+body.dark-mode .plugins-manager-add,
+body.dark-mode .plugins-manager-uninstall {
+  border-color: #4a5f8a;
+}
+
+body.dark-mode .plugins-manager-row-meta,
+body.dark-mode .plugins-store-row-meta,
+body.dark-mode .plugins-store-row-desc,
+body.dark-mode .connection-description p,
+body.dark-mode .plugins-manager-status,
+body.dark-mode .plugins-store-status,
+body.dark-mode .plugins-manager-loading,
+body.dark-mode .plugins-store-empty {
+  color: #b9c6e6;
+}
+
+body.dark-mode .plugins-store-search {
+  background: #161f32;
+  border-color: #4a5f8a;
+  color: #eef3ff;
+}
+
+body.dark-mode .plugins-toggle-ui {
+  background: #2a3551;
+  border-color: #4a5f8a;
+}
+
+body.dark-mode .plugins-toggle input:checked + .plugins-toggle-ui {
+  background: #8ea6df;
+  border-color: #8ea6df;
+}
+
+body.dark-mode .plugins-toggle input:checked + .plugins-toggle-ui::after {
+  background: #0e1628;
+}
+
+body.dark-mode .connection-button {
+  background: #506595;
+  color: #f6f9ff;
+}
+
+body.dark-mode .connection-button:hover {
+  background: #5e77ae;
+}
+
+body.dark-mode .settings-reset {
+  background: #5e2a2d;
+  border-color: #8f4348;
+  color: #ffd7d9;
+}
+
+body.dark-mode .settings-reset:hover {
+  background: #743236;
 }
 
 /* Legacy support for old class name */


### PR DESCRIPTION
Adds a top-bar theme toggle and polished dark theme coverage while preserving layout behavior across mode switches.

Highlights:
- Persists selected theme with localStorage (uiTheme) and restores on launch.
- Moon-style toggle icon with visible state styling and updated tooltip/aria labels.
- Dark-mode styling pass for setup screen, bindings list, profile dropdown, target panel, plugins window/store, action controls, and scrollbars.
- OSD safeguard: OSD-only window remains transparent regardless of saved theme.

Files changed:
- src/index.html
- src/main.js
- src/styles.css