### PR TITLE
Bump release version to 0.3.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MIDIMaster",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "com.midimaster.midimaster",
   "build": {
     "beforeDevCommand": "",


### PR DESCRIPTION
## Summary
- bump Tauri app version to 0.3.0 in src-tauri/tauri.conf.json

## Why
- prepare 0.3.0 tag so GitHub Actions release workflow can build and publish artifacts