### PR TITLE
Add visual feedback to bindings

### DIFF
--- a/src/features/bindings/bindings.js
+++ b/src/features/bindings/bindings.js
@@ -769,6 +769,7 @@ export function createBindingsFeature({
         row.className = "binding-row";
 
         item.dataset.index = index;
+        item.dataset.bindingId = String(binding.id || "");
 
         const fallbackName = fallbackNameFor(binding, index);
         const isEditing = binding.id === getEditingId();

--- a/src/main.js
+++ b/src/main.js
@@ -708,6 +708,16 @@ function updateSliderFill(slider) {
   bindingsFeature?.updateSliderFill?.(slider);
 }
 
+function flashBindingTrigger(bindingId) {
+  if (!bindingId) return;
+  const selector = `.binding-item[data-binding-id="${CSS.escape(String(bindingId))}"]`;
+  document.querySelectorAll(selector).forEach((el) => {
+    el.classList.add("triggered");
+    clearTimeout(el._triggerTimer);
+    el._triggerTimer = setTimeout(() => el.classList.remove("triggered"), 300);
+  });
+}
+
 function isBindingTargetMenuOpen() {
   return Boolean(document.querySelector(".target-dropdown.open"));
 }
@@ -1723,6 +1733,7 @@ async function setupListeners() {
     if (!binding || getBindingTargets(binding).length === 0) {
       return;
     }
+    flashBindingTrigger(binding.id);
     if (binding.action === "ToggleMute") {
       return;
     }

--- a/src/styles/bindings-and-panels.css
+++ b/src/styles/bindings-and-panels.css
@@ -1261,6 +1261,18 @@ body.dark-mode .osd-position-dot.selected {
   opacity: 0.6;
 }
 
+.binding-item {
+  transition: box-shadow 350ms ease-out;
+}
+
+.binding-item.triggered {
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.18), inset 0 0 0 2px rgba(99, 102, 241, 0.7);
+}
+
+body.dark-mode .binding-item.triggered {
+  box-shadow: 0 0 0 4px rgba(129, 140, 248, 0.22), inset 0 0 0 2px rgba(129, 140, 248, 0.8);
+}
+
 .binding-placeholder {
   border-radius: 8px;
   background: #eef1fb;


### PR DESCRIPTION
## Summary
- Binding items in the list now pulse with an indigo glow when triggered by MIDI
- Glow stays active while events stream in (debounced 300ms past last event)
- Fades in/out via CSS `box-shadow` transition, no looping pulse

## Implementation
- `src/features/bindings/bindings.js` — set `data-binding-id` on each binding item root
- `src/main.js` — `flashBindingTrigger(id)` helper called from the `midi_event` listener once a binding is resolved; stashes timeout on the element and clears/resets on each incoming event
- `src/styles/bindings-and-panels.css` — `.binding-item.triggered` sets a static glow; base selector has `transition: box-shadow 350ms ease-out` for the fade
- Dark-mode variant uses a lighter indigo (`rgba(129, 140, 248, ...)`)

## Test plan
- [ ] Move a fader bound to a volume target — binding pulses smoothly while moving, fades out ~300ms after stopping
- [ ] Press a button bound to ToggleMute / Hotkey / OpenApplication — single pulse visible
- [ ] Trigger bindings with integration targets (OBS / WaveLink) — pulse visible
- [ ] Toggle dark mode — glow color matches theme
- [ ] Rapid input on multiple bindings at once — each pulses independently