### PR TITLE
Double-click binding name to rename

### DIFF
--- a/src/features/bindings/bindings.js
+++ b/src/features/bindings/bindings.js
@@ -846,6 +846,10 @@ export function createBindingsFeature({
           const nameLabel = document.createElement("div");
           nameLabel.className = "binding-name";
           nameLabel.textContent = binding.name?.trim() || fallbackName;
+          nameLabel.title = "Double-click to rename";
+          nameLabel.addEventListener("dblclick", () => {
+            beginBindingEdit(binding.id, true);
+          });
           nameField = nameLabel;
         }
 

--- a/src/styles/bindings-and-panels.css
+++ b/src/styles/bindings-and-panels.css
@@ -1206,6 +1206,8 @@ body.dark-mode .osd-position-dot.selected {
   border: 1px solid transparent;
   color: #2b2d42;
   background: transparent;
+  cursor: text;
+  user-select: none;
 }
 
 .binding-item {


### PR DESCRIPTION
## Summary
- Double-clicking a binding's name opens the inline rename editor
- Matches the behavior of the pencil button for button bindings, and bypasses the fader config modal so the name is always what gets edited
- Cursor and tooltip hint the affordance; `user-select: none` prevents the text-selection flash on double-click

## Implementation
- `src/features/bindings/bindings.js` — `dblclick` listener on the `.binding-name` label calls `beginBindingEdit(binding.id, true)` (`forceInline = true` so faders also rename inline)
- `src/styles/bindings-and-panels.css` — `.binding-name` gets `cursor: text` and `user-select: none`

## Test plan
- [ ] Double-click a button binding's name — input appears, rename commits on blur/enter
- [ ] Double-click a fader binding's name — same inline rename (no fader config modal)
- [ ] Single-click still does nothing / does not enter edit mode
- [ ] Pencil button still works as before (fader → config modal, button → rename)
- [ ] No text-selection flash on double-click