### PR TITLE
connections-sidebar: vertical scroll on overflow

### DIFF
--- a/src/styles/connections-and-plugins.css
+++ b/src/styles/connections-and-plugins.css
@@ -210,6 +210,8 @@
   flex-direction: column;
   padding: 10px 6px;
   gap: 2px;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .connections-nav-item {


### PR DESCRIPTION
## Summary
- Add \`overflow-y: auto\` + \`min-height: 0\` to \`.connections-sidebar\` so the nav list scrolls when more plugins are installed than fit in the panel height.

## Test plan
- [ ] Install enough plugins that the sidebar nav overflows 365px.
- [ ] Open Connections panel, verify a vertical scrollbar appears on the sidebar only.
- [ ] Verify non-overflow case still renders unchanged.